### PR TITLE
replace device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/healthchecksio/__init__.py
+++ b/custom_components/healthchecksio/__init__.py
@@ -101,7 +101,7 @@ class HealthchecksioData:
             verify_ssl = not self.self_hosted or self.site_root.startswith("https")
             session = async_get_clientsession(self.hass, verify_ssl)
             headers = {"X-Api-Key": self.api_key}
-            async with async_timeout.timeout(10, loop=asyncio.get_event_loop()):
+            async with async_timeout.timeout(10):
                 data = await session.get(
                     f"{self.site_root}/api/v1/checks/", headers=headers
                 )

--- a/custom_components/healthchecksio/__init__.py
+++ b/custom_components/healthchecksio/__init__.py
@@ -101,7 +101,7 @@ class HealthchecksioData:
             verify_ssl = not self.self_hosted or self.site_root.startswith("https")
             session = async_get_clientsession(self.hass, verify_ssl)
             headers = {"X-Api-Key": self.api_key}
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(10, loop=asyncio.get_event_loop()):
                 data = await session.get(
                     f"{self.site_root}/api/v1/checks/", headers=headers
                 )

--- a/custom_components/healthchecksio/binary_sensor.py
+++ b/custom_components/healthchecksio/binary_sensor.py
@@ -80,6 +80,6 @@ class HealthchecksioBinarySensor(BinarySensorEntity):
         return self._status
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self.attr


### PR DESCRIPTION
`device_state_attributes` is deprecated from 2021.12 and will be removed in 2022.4. Replaced by `extra_state_attributes`.

