### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/custom_components/healthchecksio/__init__.py
+++ b/custom_components/healthchecksio/__init__.py
@@ -101,7 +101,7 @@ class HealthchecksioData:
             verify_ssl = not self.self_hosted or self.site_root.startswith("https")
             session = async_get_clientsession(self.hass, verify_ssl)
             headers = {"X-Api-Key": self.api_key}
-            async with async_timeout.timeout(10, loop=asyncio.get_event_loop()):
+            async with async_timeout.timeout(10):
                 data = await session.get(
                     f"{self.site_root}/api/v1/checks/", headers=headers
                 )


### PR DESCRIPTION
In 2021.12 aiohttp is bumped to 3.8.0 (#58974) which has async_timeout 4.0.0 which in turn drops the loop= kwarg and will fail if its passed

(150 deprecation warnings in 12 hours 😅)

This fixes #23 