### PR TITLE
Consider "grace" state as Connected

### DIFF
--- a/custom_components/healthchecksio/binary_sensor.py
+++ b/custom_components/healthchecksio/binary_sensor.py
@@ -46,7 +46,7 @@ class HealthchecksioBinarySensor(BinarySensorEntity):
             if self.unique_id == check.get("ping_url").split("/")[-1]:
                 self.check = check
                 break
-        self._status = self.check.get("status") in ["up", "grace"] 
+        self._status = self.check.get("status") != "down"
 
         # Set/update attributes
         self.attr["attribution"] = ATTRIBUTION

--- a/custom_components/healthchecksio/binary_sensor.py
+++ b/custom_components/healthchecksio/binary_sensor.py
@@ -46,7 +46,7 @@ class HealthchecksioBinarySensor(BinarySensorEntity):
             if self.unique_id == check.get("ping_url").split("/")[-1]:
                 self.check = check
                 break
-        self._status = self.check.get("status") == "up"
+        self._status = self.check.get("status") in ["up", "grace"] 
 
         # Set/update attributes
         self.attr["attribution"] = ATTRIBUTION


### PR DESCRIPTION
Fixes #37 

If the sensor polls the status during a grace period, the binary sensor will be set to off for 5 minutes.
Since this component is a binary sensor, we must choose if the "grace" period is associated to "up" or "down".
I think it's legitimate to stay "up" / "on" since the grace period is an uncertainty period and can give false positive triggers if the binary sensor is immediately set to "off".