### PR TITLE
Fix potential mutable dict issue

### DIFF
--- a/custom_components/healthchecksio/config_flow.py
+++ b/custom_components/healthchecksio/config_flow.py
@@ -1,11 +1,12 @@
 """Adds config flow for Blueprint."""
-import async_timeout
 import asyncio
 from collections import OrderedDict
+
+import async_timeout
 import voluptuous as vol
+from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from integrationhelper import Logger
-from homeassistant import config_entries
 
 from .const import DOMAIN, DOMAIN_DATA, OFFICIAL_SITE_ROOT
 
@@ -22,9 +23,7 @@ class BlueprintFlowHandler(config_entries.ConfigFlow):
         self._errors = {}
         self.initial_data = None
 
-    async def async_step_user(
-        self, user_input={}
-    ):  # pylint: disable=dangerous-default-value
+    async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         self._errors = {}
         if self._async_current_entries():
@@ -78,9 +77,7 @@ class BlueprintFlowHandler(config_entries.ConfigFlow):
             step_id="user", data_schema=vol.Schema(data_schema), errors=self._errors
         )
 
-    async def async_step_self_hosted(
-        self, user_input={}
-    ):  # pylint: disable=dangerous-default-value
+    async def async_step_self_hosted(self, user_input):
         """Handle the step for a self-hosted instance."""
         self._errors = {}
         valid = await self._test_credentials(


### PR DESCRIPTION
Function defaults are evaluated once, when the function is defined.

The same mutable object is then shared across all calls to the function. If the object is modified, those modifications will persist across calls, which can lead to unexpected behavior.

Instead, prefer to use immutable data structures, or take None as a default, and initialize a new mutable object inside the function body for each call.