### PR TITLE
Migrate to async_forward_entry_setups

### DIFF
--- a/custom_components/healthchecksio/__init__.py
+++ b/custom_components/healthchecksio/__init__.py
@@ -27,6 +27,9 @@ from .const import (
 )
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup(hass: core.HomeAssistant, config: ConfigType):
@@ -73,13 +76,7 @@ async def async_setup_entry(
         hass, api_key, check, self_hosted, site_root, ping_endpoint
     )
 
-    # Add binary_sensor
-    hass.async_add_job(
-        hass.config_entries.async_forward_entry_setup(
-            config_entry, Platform.BINARY_SENSOR
-        )
-    )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
To remove the following warning:
```
Logger: homeassistant.helpers.frame
Quelle: helpers/frame.py:151
Erstmals aufgetreten: 26. Juni 2024 um 17:30:51 (1 Vorkommnisse)
Zuletzt protokolliert: 26. Juni 2024 um 17:30:51

Detected code that calls async_forward_entry_setup for integration, healthchecksio with title: [REMOVED] and entry_id: [REMOVED], which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead. Please report this issue.
```